### PR TITLE
Not auto-merging major version bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: "Fetch Dependabot metadata"
+        id: "metadata"
+        uses: dependabot/fetch-metadata@v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Enable auto-merge for the request"
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Uses `dependabot/fetch-metadata` to skip auto-merge for `version-update:semver-major` updates, so major bumps stay open for manual review.

Note: for grouped Dependabot PRs, `update-type` reports the highest bump in the group, so a group containing a major update is left alone entirely.