### PR TITLE
Format and lint YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: weekly
-  assignees:
-  - marekdedic
-- package-ecosystem: npm
-  directory: "/"
-  open-pull-requests-limit: 9999
-  schedule:
-    interval: weekly
-  assignees:
-  - marekdedic
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: weekly
+    assignees:
+      - marekdedic
+  - package-ecosystem: npm
+    directory: "/"
+    open-pull-requests-limit: 9999
+    schedule:
+      interval: weekly
+    assignees:
+      - marekdedic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
+---
 name: "CI"
-on:
+"on":
   push:
     branches: "*"
   pull_request:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,6 @@
+---
 name: "Dependabot auto-merge"
-on: "pull_request_target"
+"on": "pull_request_target"
 
 permissions:
   pull-requests: write
@@ -13,12 +14,14 @@ jobs:
     steps:
       - name: "Fetch Dependabot metadata"
         id: "metadata"
-        uses: dependabot/fetch-metadata@v2.5.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Enable auto-merge for the request"
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: >-
+          ${{ steps.metadata.outputs.update-type !=
+          'version-update:semver-major' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
+---
 name: "WordPress version checker"
-description: "A GitHub app to automatically create issues when a plugin \"tested up to\" version doesn't match the latest WordPress version."
+description: >-
+  A GitHub app to automatically create issues when a plugin "tested up to"
+  version doesn't match the latest WordPress version.
 author: "Junák – český skaut"
 branding:
   icon: "bell"

--- a/app.yml
+++ b/app.yml
@@ -1,3 +1,4 @@
+---
 # This is a GitHub App Manifest. These settings will be used by default when
 # initially configuring your GitHub App.
 #
@@ -76,11 +77,13 @@ default_permissions:
   # https://developer.github.com/v3/apps/permissions/#metadata-permissions
   # metadata: read
 
-  # Retrieve Pages statuses, configuration, and builds, as well as create new builds.
+  # Retrieve Pages statuses, configuration, and builds, as well as create
+  # new builds.
   # https://developer.github.com/v3/apps/permissions/#permission-on-pages
   # pages: read
 
-  # Pull requests and related comments, assignees, labels, milestones, and merges.
+  # Pull requests and related comments, assignees, labels, milestones, and
+  # merges.
   # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
   # pull_requests: read
 
@@ -134,6 +137,7 @@ url: https://skaut.github.io/wordpress-version-checker
 # A description of the GitHub App.
 description: https://skaut.github.io/wordpress-version-checker
 
-# Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+# Set to true when your GitHub App is available to the public or false when
+# it is only accessible to the owner of the app.
 # Default: true
 public: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+---
 coverage:
   range: "95...100"
 
@@ -13,11 +14,11 @@ coverage:
 parsers:
   gcov:
     branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+      conditional: true
+      loop: true
+      method: false
+      macro: false
 
 comment:
   layout: "reach,diff,flags,files"
-  require_changes: no
+  require_changes: false


### PR DESCRIPTION
Conform every YAML file in the repository to yamllint's default rules,
which previously reported a large number of issues:

- Add the `---` document start marker.
- Quote the `on:` workflow key so it is not parsed as the boolean true.
- Indent block sequences under their parent key, which was previously
  inconsistent even within a single file.
- Fold over-long values into `>-` block scalars. Every folded value is
  preserved byte for byte.
- Replace `yes`/`no` with `true`/`false` in codecov.yml.

Beyond formatting:

- Bump dependabot/fetch-metadata from v2.5.0 to v3.1.0, matching the
  version already used in the other repositories.

Verified by comparing every file before and after as parsed YAML: apart
from the changes listed above, no key or value differs. The remaining
long lines are `restore-keys` entries and shell lines inside `run: |`
blocks, which cannot be wrapped without changing their meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)