### PR TITLE
Don't count test helpers in coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
     exclude: NODE_BUILT_IN_MODULES,
   },
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     mockReset: true,
     setupFiles: ["tests/setup.ts"],
   },


### PR DESCRIPTION
The tests directory was being measured as if it were production code.
Vitest's default `coverage.exclude` matches test *file name* patterns
(`**/*.{test,spec}.*`) rather than test *directories*, so files under
`tests/` that don't carry `.test.` in their name were instrumented, because
the tests import them.

In this repository 3 of the 22 measured files were the JSON fixtures under
`tests/version-check-responses/`, accounting for roughly 3 % of the measured
lines. The effect on the reported figure is nil, but data files have no
business being in a coverage report.

Exclude `tests/**` from coverage. Doing this in the vitest config rather than
through `codecov.yml`'s `ignore` key keeps a local `npm run test-coverage` run
consistent with CI, and leaves `codecov.yml` byte-identical across all the
repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)