### PR TITLE
Removed an unused tsconfig

### DIFF
--- a/test.tsconfig.json
+++ b/test.tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "allowJs": true
-  }
-}


### PR DESCRIPTION
Nothing references `test.tsconfig.json`. It sets only `allowJs: true` on top of the base config, and no script, workflow, or config file names it.

It is a leftover from when typescript-eslint took an explicit `project` list. `eslint.config.js` now uses `projectService: true`, which resolves each file against the nearest `tsconfig.json` and never looks at `test.tsconfig.json`.

Verified with the file deleted: `lint`, `test-coverage` and `build` all pass, and `dist/` is unchanged after a rebuild so the CI `git diff --exit-code -- dist/` check still passes.