### PR TITLE
Update the action runtime from node20 to node24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ name: "CI"
     branches: "*"
   pull_request:
 env:
-  node-version: 22
+  node-version: 24
 
 jobs:
   build:

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'GitHub token'
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@eslint/js": "^10.0.1",
         "@eslint/json": "^2.0.1",
         "@eslint/markdown": "^8.0.3",
-        "@types/node": "^26.4.0",
+        "@types/node": "^24.13.3",
         "@vitest/coverage-v8": "^4.1.11",
         "@vitest/eslint-plugin": "^1.6.27",
         "eslint": "^10.9.1",
@@ -39,6 +39,9 @@
         "typescript-eslint": "^8.68.0",
         "vite": "^8.1.5",
         "vitest": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@actions/core": {
@@ -1089,13 +1092,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/unist": {
@@ -6601,9 +6604,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
   "simple-git-hooks": {
     "pre-commit": "node scripts/pre-commit.js"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "@actions/core": "^3.0.1",
     "@actions/github": "^9.1.1",
@@ -57,7 +60,7 @@
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^2.0.1",
     "@eslint/markdown": "^8.0.3",
-    "@types/node": "^26.4.0",
+    "@types/node": "^24.13.3",
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/eslint-plugin": "^1.6.27",
     "eslint": "^10.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "bundler",
-    "target": "es2022",
+    "target": "es2023",
 
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     rollupOptions: {
       external: NODE_BUILT_IN_MODULES,
     },
+    target: "node24",
   },
   optimizeDeps: {
     exclude: NODE_BUILT_IN_MODULES,


### PR DESCRIPTION
Fixes #1926.

Node 20 reached end-of-life on 2026-04-30, so the action was pinned to an unsupported runtime. This bumps the declared runtime and aligns everything that follows from it, so the runtime version is stated in one place and the build and CI follow it.

- `action.yml` — `runs.using: "node20"` → `"node24"`
- `.github/workflows/CI.yml` — `node-version: 22` → `24`, so CI builds and tests on the runtime the action actually executes on
- `vite.config.ts` — set `build.target: "node24"` explicitly, instead of inheriting Vite 8's `baseline-widely-available` browser baseline (a browser constraint on a Node-only action, which would drift on every Vite major)
- `tsconfig.json` — `target: "es2022"` → `"es2023"`; Node 24 supports ES2023 in full, and `lib` is unset so it follows `target`

Verified locally: `npm run lint` (eslint + `tsc --noEmit`) clean, 89/89 tests pass, `node --check dist/index.js` parses. The rebuilt bundle is byte-identical to the committed one, so `dist/` is unchanged.