### PR TITLE
Pin node engines to ^24.0.0 matching the action runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "engines": {
-    "node": ">=24"
+    "node": "^24.0.0"
   },
   "dependencies": {
     "@actions/core": "^3.0.1",


### PR DESCRIPTION
This is a GitHub Action that runs on `using: node24` (see `action.yml`), so it is tied to a single Node major. Constrain the `engines.node` field to match:

`node`: `>=24` → `^24.0.0`