### PR TITLE
Enforce unused eslint-disable / inline-config directives

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,12 @@ export default tseslint.config(
   globalIgnores(["coverage/", "dist/", "package-lock.json"]),
   packageJson.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+      reportUnusedInlineConfigs: "error",
+    },
+  },
+  {
     extends: [json.configs.recommended],
     files: ["**/*.json"],
     ignores: ["package.json"],
@@ -54,7 +60,6 @@ export default tseslint.config(
       "default-case": "error",
       "default-case-last": "error",
       eqeqeq: "error",
-      "eslint-comments/no-unused-disable": "error",
       "eslint-comments/require-description": [
         "error",
         {

--- a/tests/issue-management.test.ts
+++ b/tests/issue-management.test.ts
@@ -18,7 +18,6 @@ import {
 vi.mock("@actions/core");
 
 describe("[env variable mock]", () => {
-  // eslint-disable-next-line @typescript-eslint/init-declarations -- Shouldn't assign outside of hooks
   let restore: () => void;
 
   beforeEach(() => {

--- a/tests/tested-version.test.ts
+++ b/tests/tested-version.test.ts
@@ -10,7 +10,6 @@ import { testedVersion } from "../src/tested-version";
 vi.mock("@actions/core");
 
 describe("[env variable mock]", () => {
-  // eslint-disable-next-line @typescript-eslint/init-declarations -- Shouldn't assign outside of hooks
   let restore: () => void;
 
   beforeEach(() => {

--- a/tests/wpvc-config.test.ts
+++ b/tests/wpvc-config.test.ts
@@ -8,7 +8,6 @@ import { getWPVCConfig } from "../src/wpvc-config";
 vi.mock("@actions/core");
 
 describe("Mocked env variables", () => {
-  // eslint-disable-next-line @typescript-eslint/init-declarations -- Shouldn't assign outside of hooks
   let restore: () => void;
 
   beforeEach(() => {


### PR DESCRIPTION
Two related changes:
- Sets `linterOptions.reportUnusedDisableDirectives: "error"` and `reportUnusedInlineConfigs: "error"` — both defaulted to `warn`.
- Removes `eslint-comments/no-unused-disable`, **deprecated since 4.7.0** and a no-op in flat config (patches `Linter#verify`, bypassed by flat config; `create()` returns `{}`). Replaced by the built-in `reportUnusedDisableDirectives`.

ESLint green.

Also removes 3 unused init-declarations disable directives in tests.