### PR TITLE
Convert ESLint config to TypeScript

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,10 +8,11 @@ import packageJson from "eslint-plugin-package-json";
 import perfectionist from "eslint-plugin-perfectionist";
 import preferArrowFunctions from "eslint-plugin-prefer-arrow-functions";
 import prettierRecommended from "eslint-plugin-prettier/recommended";
-import { globalIgnores } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
   globalIgnores(["coverage/", "dist/", "package-lock.json"]),
   packageJson.configs.recommended,
   {
@@ -191,6 +192,11 @@ export default tseslint.config(
   },
   {
     files: ["scripts/**/*.js"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
     rules: {
       "no-console": "off",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "eslint-plugin-perfectionist": "^5.10.1",
         "eslint-plugin-prefer-arrow-functions": "^3.10.2",
         "eslint-plugin-prettier": "^5.5.6",
+        "globals": "^17.12.0",
+        "jiti": "^2.7.0",
         "mocked-env": "^1.3.5",
         "nock": "^14.0.17",
         "node-fetch": "^3.3.2",
@@ -2480,6 +2482,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2614,6 +2629,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "eslint-plugin-perfectionist": "^5.10.1",
     "eslint-plugin-prefer-arrow-functions": "^3.10.2",
     "eslint-plugin-prettier": "^5.5.6",
+    "globals": "^17.12.0",
+    "jiti": "^2.7.0",
     "mocked-env": "^1.3.5",
     "nock": "^14.0.17",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
Renames `eslint.config.js`→`.ts` and adds the `jiti` devDep ESLint needs to load a TS config.

Type-checking the now-`.ts` config surfaced two latent issues the untyped `.js` version hid:
- `tseslint.config()` is deprecated → migrated to `defineConfig()`.
- Migrating exposed that the `scripts/**/*.js` block declared no Node globals, so `console`/`process` tripped `no-undef` → added `globals.node` to that block (new `globals` devDep). Verified eslint passes.